### PR TITLE
ftdetect/gentoo.vim: detect init files by shebang

### DIFF
--- a/ftdetect/gentoo.vim
+++ b/ftdetect/gentoo.vim
@@ -33,7 +33,7 @@ au BufNewFile,BufRead ChangeLog*
 au BufNewFile,BufRead /etc/init.d/*
     \     set filetype=gentoo-init-d |
 
-au BufNewFile,BufRead /*/files/*
+au BufNewFile,BufRead *
     \ if (getline(1) =~? "#!/sbin/\\(runscript\\|openrc-run\\)") |
     \     set filetype=gentoo-init-d |
     \ endif


### PR DESCRIPTION
Use only the shebang/interpreter value to detect /sbin/{openrc-run,runscript} files, do not only detect them underneath a directory called "files."